### PR TITLE
音声周りのデバッグ改善(issue #30 の修正)

### DIFF
--- a/app/controllers/readerInputController.ts
+++ b/app/controllers/readerInputController.ts
@@ -14,10 +14,19 @@ const Status = {
 } as const
 
 function playWav (fileName: string) {
-  // stdio: 'inherit'でnodeのstdioを子プロセスにも使わせる
+  // stdio: 'inherit'だとnodeのstdioに流れてしまって後で使えないので'pipe'
   // asyncなspawnだとChildProcessが返ってきて世話するのが面倒くさいので、spawnSyncを使う
   // 順番通りに最後まで再生したいのでspawnSyncを使う
-  spawnSync('aplay', ['-q', fileName + '.wav'], { cwd: WAV_FILE_DIR, stdio: 'inherit' })
+  const aplay = spawnSync('aplay', [fileName + '.wav'], { cwd: WAV_FILE_DIR, stdio: 'pipe' })
+
+  // spawnSync().errorはコマンドを実行できなかった際にErrorオブジェクトが入る
+  if (aplay.error) {
+    console.error('[!] spawnSync error:', aplay.error)
+  // spawnSync().statusは実行したコマンドの終了コードが入る
+  // errorではないのでnullではないはずだが一応確認
+  } else if (aplay.status !== null && aplay.status !== 0) {
+    console.error('[!] aplay error:', aplay.stderr)
+  }
 }
 
 async function handleReaderInput (req: Request, res: Response) {


### PR DESCRIPTION
@Stroheim001 #30 の修正です．コマンドが見つからなかったとき，コマンドを実行したけれども終了コードが0でなかったときの2パターンを拾えるように修正したつもりです．自分の手元のマシン(WSL，初代ラズパイ)ではissueに指摘のあるSQLクエリが飛ばない現象が再現できない(一瞬あったような気もするけど)ので，これでうまくいくのか実験していただければと思います．