### PR TITLE
フロントエンドへの通知

### DIFF
--- a/ams-backend-server.ts
+++ b/ams-backend-server.ts
@@ -1,7 +1,8 @@
 import express from 'express'
 import accesslogsRoutes from './app/routes/accessLogsRoutes'
-import readerInputRoutes from './app/routes/readerInputRoutes'
 import inRoomUsersRoutes from './app/routes/inRoomUsersRoutes'
+import readerInputRoutes from './app/routes/readerInputRoutes'
+import sseRoutes from './app/routes/sseRoutes'
 import { amsOptions } from './config'
 
 const app: express.Express = express()
@@ -18,7 +19,7 @@ app.get('/', (_req, res) => {
 })
 
 // set middlewares
-app.use('/v1', accesslogsRoutes, readerInputRoutes, inRoomUsersRoutes)
+app.use('/v1', accesslogsRoutes, inRoomUsersRoutes, readerInputRoutes, sseRoutes)
 
 // set port, listen for requests
 const PORT = amsOptions.port

--- a/app/controllers/accessLogsController.ts
+++ b/app/controllers/accessLogsController.ts
@@ -38,7 +38,7 @@ async function listAccessLogs (req: Request, res: Response) {
     DATA_PAR_PAGE * (page - 1))
 
   if (error2) {
-    res.status(500).json({ message: error?.message || 'internal server error' })
+    res.status(500).json({ message: error2?.message || 'internal server error' })
   } else {
     const urlOfEndpoint = req.protocol + '://' + req.hostname + ':' + amsOptions.port + req.baseUrl + req.path
 

--- a/app/controllers/readerInputController.ts
+++ b/app/controllers/readerInputController.ts
@@ -64,7 +64,6 @@ async function handleReaderInput (req: Request, res: Response) {
     return
   }
 
-  // reader-bridgeからのリクエストを正しく受け取ったことを音で知らせる
   switch (readerStatus) {
     case Status.SUCCESS:
       // ちゃんとしたIDが来ているかチェック

--- a/app/controllers/readerInputController.ts
+++ b/app/controllers/readerInputController.ts
@@ -15,6 +15,7 @@ const Status = {
   FATAL: 'fatal'
 } as const
 
+// フロントエンドに通知するためのイベントを定義。sseHandler関数にlistenさせる
 const emitter = new EventEmitter()
 
 function playWav (fileName: string) {
@@ -127,6 +128,7 @@ async function handleReaderInput (req: Request, res: Response) {
   // 処理が一通り終わったので音を鳴らす
   playWav(isExit ? 'out' : 'in')
 
+  // イベントの発火
   emitter.emit('usersUpdated')
 
   res.status(204).send()

--- a/app/controllers/readerInputController.ts
+++ b/app/controllers/readerInputController.ts
@@ -18,6 +18,12 @@ const Status = {
 // フロントエンドに通知するためのイベントを定義。sseHandler関数にlistenさせる
 const emitter = new EventEmitter()
 
+// 検知してもどうしようも無いがもしエラーが出たら記録する
+emitter.on('error', () => {
+  console.error('[!] Some error related to "emitter(node:events.EventEmitter)" has occured')
+  // さいきょうのえらーはんどりんぐ
+})
+
 function playWav (fileName: string) {
   // stdio: 'inherit'だとnodeのstdioに流れてしまって後で使えないので'pipe'
   // asyncなspawnだとChildProcessが返ってきて世話するのが面倒くさいので、spawnSyncを使う

--- a/app/controllers/readerInputController.ts
+++ b/app/controllers/readerInputController.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 import { spawnSync } from 'child_process'
+import { EventEmitter } from 'events'
 import { Request, Response } from 'express'
 import { join } from 'path'
 import * as roomTable from '../models/inRoomUsersModel'
@@ -13,6 +14,8 @@ const Status = {
   ERROR: 'error',
   FATAL: 'fatal'
 } as const
+
+const emitter = new EventEmitter()
 
 function playWav (fileName: string) {
   // stdio: 'inherit'だとnodeのstdioに流れてしまって後で使えないので'pipe'
@@ -124,7 +127,9 @@ async function handleReaderInput (req: Request, res: Response) {
   // 処理が一通り終わったので音を鳴らす
   playWav(isExit ? 'out' : 'in')
 
+  emitter.emit('usersUpdated')
+
   res.status(204).send()
 }
 
-export { handleReaderInput }
+export { emitter, handleReaderInput }

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -31,6 +31,7 @@ export function sseHandler (_req: Request, res: Response) {
   // ブラウザーの再読み込みを繰り返すとその度にEventEmitterにlistenerが追加され、10を超えると
   // 'MaxListenersExceededWarning: Possible EventEmitter memory leak detected.'
   // のような警告が出る。とりあえずは警告が出そうになったらこのイベントに登録済みのlistenerたちを解除する
+  // TODO EventEmitterからlistenerが外れてもフロントエンド側とのコネクションが切れるわけではないのでそこを何とかする
   if (emitter.listenerCount('usersUpdated') + 1 > EventEmitter.defaultMaxListeners) {
     emitter.removeAllListeners('usersUpdated')
   }

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -9,13 +9,14 @@ import EventEmitter from 'events'
 const frontEndOrigin = 'http://localhost:8000'
 
 /**
+ * @param {Express.Request} _req - HTTPリクエスト
+ * @param {Express.Response} res - HTTPレスポンス
  * `/{version}/sse`に来たリクエストにストリームを開いて繋ぎっぱなしにする。
  * 在室者のリストの変更を検知して更新されたリストをpush(≒プッシュ通知)する。
  *
  * Server-Sent eventsについて
  * https://html.spec.whatwg.org/multipage/server-sent-events.html
  */
-
 export function sseHandler (_req: Request, res: Response) {
   res.set({
     'Access-Control-Allow-Origin': frontEndOrigin, // オリジン間リソース共有をこのオリジンとだけ許可
@@ -38,7 +39,7 @@ export function sseHandler (_req: Request, res: Response) {
     const [users, err] = await roomTable.listUsers()
     if (err) {
       // status codeが4xxや5xxだった時点でクライアント側ではEventSourceのerrorイベントが
-      // 発火する。数秒後に再接続をトライするっぽい?
+      // 発火する。たぶん数秒後に再接続をトライする
       res.status(500).json({ message: err?.message || 'internal server error' })
     } else {
       // イベント名は任意。小文字の方がいいのかな?

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -23,8 +23,7 @@ export function sseHandler (_req: Request, res: Response) {
   res.set({
     'Access-Control-Allow-Origin': frontEndOrigin, // オリジン間リソース共有をこのオリジンとだけ許可
     'Content-Type': 'text/event-stream', // event-streamでクライアント-サーバー間を繋ぎっぱなしにする
-    'Cache-Control': 'no-cache', // 参考にしたサイトの多くで使用されていたのでno-cacheを指定(無くてもよさげ)
-    Connection: 'keep-alive' // 参考にしたサイトの多くで使用されていたので
+    'Cache-Control': 'no-store' // レスポンスがキャッシュに保存されないようにする(クライアント側でも同じことをしているが一応)
   })
 
   // hello world

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -1,26 +1,48 @@
 import { Request, Response } from 'express'
 import { emitter } from './readerInputController'
 import * as roomTable from '../models/inRoomUsersModel'
+import EventEmitter from 'events'
 
 /**
  * CORS用
  */
 const frontEndOrigin = 'http://localhost:8000'
 
-export function sseHandler (req: Request, res: Response) {
+/**
+ * `/{version}/sse`に来たリクエストにストリームを開いて繋ぎっぱなしにする。
+ * 在室者のリストの変更を検知して更新されたリストをpush(≒プッシュ通知)する。
+ *
+ * Server-Sent eventsについて
+ * https://html.spec.whatwg.org/multipage/server-sent-events.html
+ */
+
+export function sseHandler (_req: Request, res: Response) {
   res.set({
-    'Access-Control-Allow-Origin': frontEndOrigin,
+    'Access-Control-Allow-Origin': frontEndOrigin, // オリジン間リソース共有をこのオリジンとだけ許可
     'Content-Type': 'text/event-stream' // event-streamでクライアント-サーバー間を繋ぎっぱなしにする
   })
-  res.status(200).write('data: hello\n\n') // nnは必須
 
+  // hello world
+  res.status(200).write('event: hello\ndata: hello\n\n') // nnは必須 コネクションが切れてしまうのでsend()は使わない
+
+  // ブラウザーの再読み込みを繰り返すとその度にEventEmitterにlistenerが追加され、10を超えると
+  // 'MaxListenersExceededWarning: Possible EventEmitter memory leak detected.'
+  // のような警告が出る。とりあえずは警告が出そうになったらこのイベントに登録済みのlistenerたちを解除する
+  if (emitter.listenerCount('usersUpdated') + 1 > EventEmitter.defaultMaxListeners) {
+    emitter.removeAllListeners('usersUpdated')
+  }
+
+  // readerInputControllerで処理が走るとuserUpdatedイベントが発火するので、
+  // そのタイミングでクライアントにpushするためにリスナーを登録する
   emitter.on('usersUpdated', async function sendUsersUpdatedEvent () {
     const [users, err] = await roomTable.listUsers()
     if (err) {
-      // status codeが4xxや5xxだった時点でEventSource(クライアント側)はcloseする。再接続もしない
+      // status codeが4xxや5xxだった時点でクライアント側ではEventSourceのerrorイベントが
+      // 発火する。数秒後に再接続をトライするっぽい?
       res.status(500).json({ message: err?.message || 'internal server error' })
     } else {
-      res.status(200).write(`data: ${JSON.stringify(users)}\n\n`)
+      // イベント名は任意。小文字の方がいいのかな?
+      res.status(200).write(`event: usersUpdated\ndata: ${JSON.stringify(users)}\n\n`)
     }
   })
 }

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -20,7 +20,8 @@ const frontEndOrigin = 'http://localhost:8000'
 export function sseHandler (_req: Request, res: Response) {
   res.set({
     'Access-Control-Allow-Origin': frontEndOrigin, // オリジン間リソース共有をこのオリジンとだけ許可
-    'Content-Type': 'text/event-stream' // event-streamでクライアント-サーバー間を繋ぎっぱなしにする
+    'Content-Type': 'text/event-stream', // event-streamでクライアント-サーバー間を繋ぎっぱなしにする
+    'Cache-Control': 'no-cache' // 参考にしたサイトの多くでしようされていたのでno-cacheを指定(無くてもよさげ)
   })
 
   // hello world

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -1,0 +1,9 @@
+import { Request, Response } from 'express'
+
+export function sseHandler (req: Request, res: Response) {
+  res.setHeader('Access-Control-Allow-Origin', 'http://localhost:8000')
+  res.setHeader('Content-Type', 'text/event-stream')
+  setInterval(() => {
+    res.status(200).write('event: message\ndata: ' + JSON.stringify({ greeting: 'Hello!', now: new Date().toISOString() }) + '\n\n')
+  }, 2000)
+}

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -6,6 +6,7 @@ import EventEmitter from 'events'
 
 /**
  * CORS用
+ * // TODO corsブランチをマージしたら消す
  */
 const frontEndOrigin = 'http://localhost:8000'
 

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -22,7 +22,8 @@ export function sseHandler (_req: Request, res: Response) {
   res.set({
     'Access-Control-Allow-Origin': frontEndOrigin, // オリジン間リソース共有をこのオリジンとだけ許可
     'Content-Type': 'text/event-stream', // event-streamでクライアント-サーバー間を繋ぎっぱなしにする
-    'Cache-Control': 'no-cache' // 参考にしたサイトの多くで使用されていたのでno-cacheを指定(無くてもよさげ)
+    'Cache-Control': 'no-cache', // 参考にしたサイトの多くで使用されていたのでno-cacheを指定(無くてもよさげ)
+    Connection: 'keep-alive' // 参考にしたサイトの多くで使用されていたので
   })
 
   // hello world

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { Request, Response } from 'express'
 import { emitter } from './readerInputController'
 import * as roomTable from '../models/inRoomUsersModel'
@@ -43,6 +44,10 @@ export function sseHandler (_req: Request, res: Response) {
       // 発火する。たぶん数秒後に再接続をトライする
       res.status(500).json({ message: err?.message || 'internal server error' })
     } else {
+      // とりあえずuser_nameは仮で割り当てる
+      (users as Array<{ user_id: number, user_name?: string, entered_at: Date }>).forEach(user => {
+        user.user_name = '辻野あかり'
+      })
       try {
         const json = JSON.stringify(users)
         // イベント名は任意。全て小文字の方がいいのかな?

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -2,9 +2,17 @@ import { Request, Response } from 'express'
 import { emitter } from './readerInputController'
 import * as roomTable from '../models/inRoomUsersModel'
 
+/**
+ * CORS用
+ */
+const frontEndOrigin = 'http://localhost:8000'
+
 export function sseHandler (req: Request, res: Response) {
-  res.setHeader('Access-Control-Allow-Origin', 'http://localhost:8000')
-  res.setHeader('Content-Type', 'text/event-stream')
+  res.set({
+    'Access-Control-Allow-Origin': frontEndOrigin,
+    'Content-Type': 'text/event-stream' // event-streamでクライアント-サーバー間を繋ぎっぱなしにする
+  })
+  res.status(200).write('data: hello\n\n') // nnは必須
 
   emitter.on('usersUpdated', async () => {
     const [users, err] = await roomTable.listUsers()
@@ -12,8 +20,7 @@ export function sseHandler (req: Request, res: Response) {
       // do something
       res.status(500).send('error')
     } else {
-      // do something
-      res.status(200).json(users)
+      res.status(200).write(`data: ${JSON.stringify(users)}\n\n`)
     }
   })
 }

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -14,11 +14,11 @@ export function sseHandler (req: Request, res: Response) {
   })
   res.status(200).write('data: hello\n\n') // nnは必須
 
-  emitter.on('usersUpdated', async () => {
+  emitter.on('usersUpdated', async function sendUsersUpdatedEvent () {
     const [users, err] = await roomTable.listUsers()
     if (err) {
-      // do something
-      res.status(500).send('error')
+      // status codeが4xxや5xxだった時点でEventSource(クライアント側)はcloseする。再接続もしない
+      res.status(500).json({ message: err?.message || 'internal server error' })
     } else {
       res.status(200).write(`data: ${JSON.stringify(users)}\n\n`)
     }

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -1,9 +1,19 @@
 import { Request, Response } from 'express'
+import { emitter } from './readerInputController'
+import * as roomTable from '../models/inRoomUsersModel'
 
 export function sseHandler (req: Request, res: Response) {
   res.setHeader('Access-Control-Allow-Origin', 'http://localhost:8000')
   res.setHeader('Content-Type', 'text/event-stream')
-  setInterval(() => {
-    res.status(200).write('event: message\ndata: ' + JSON.stringify({ greeting: 'Hello!', now: new Date().toISOString() }) + '\n\n')
-  }, 2000)
+
+  emitter.on('usersUpdated', async () => {
+    const [users, err] = await roomTable.listUsers()
+    if (err) {
+      // do something
+      res.status(500).send('error')
+    } else {
+      // do something
+      res.status(200).json(users)
+    }
+  })
 }

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -44,6 +44,7 @@ export function sseHandler (_req: Request, res: Response) {
       // 発火する。たぶん数秒後に再接続をトライする
       res.status(500).json({ message: err?.message || 'internal server error' })
     } else {
+      // TODO
       // とりあえずuser_nameは仮で割り当てる。user_nameはstringかnullにしてある(undefinedではない!)
       // 最悪Array<any>でも可
       (users as Array<{ user_id: number, user_name: string | null, entered_at: Date }>).forEach(user => {

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -44,9 +44,10 @@ export function sseHandler (_req: Request, res: Response) {
       // 発火する。たぶん数秒後に再接続をトライする
       res.status(500).json({ message: err?.message || 'internal server error' })
     } else {
-      // とりあえずuser_nameは仮で割り当てる
-      (users as Array<{ user_id: number, user_name?: string, entered_at: Date }>).forEach(user => {
-        user.user_name = '辻野あかり'
+      // とりあえずuser_nameは仮で割り当てる。user_nameはstringかnullにしてある(undefinedではない!)
+      // 最悪Array<any>でも可
+      (users as Array<{ user_id: number, user_name: string | null, entered_at: Date }>).forEach(user => {
+        user.user_name = null
       })
       try {
         const json = JSON.stringify(users)

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -25,7 +25,7 @@ export function sseHandler (_req: Request, res: Response) {
   })
 
   // hello world
-  res.status(200).write('event: hello\ndata: hello\n\n') // nnは必須 コネクションが切れてしまうのでsend()は使わない
+  res.status(200).write('data: hello\n\n') // nnは必須 コネクションが切れてしまうのでsend()は使わない
 
   // ブラウザーの再読み込みを繰り返すとその度にEventEmitterにlistenerが追加され、10を超えると
   // 'MaxListenersExceededWarning: Possible EventEmitter memory leak detected.'
@@ -43,8 +43,14 @@ export function sseHandler (_req: Request, res: Response) {
       // 発火する。たぶん数秒後に再接続をトライする
       res.status(500).json({ message: err?.message || 'internal server error' })
     } else {
-      // イベント名は任意。小文字の方がいいのかな?
-      res.status(200).write(`event: usersUpdated\ndata: ${JSON.stringify(users)}\n\n`)
+      try {
+        const json = JSON.stringify(users)
+        // イベント名は任意。全て小文字の方がいいのかな?
+        res.status(200).write(`event: usersUpdated\ndata: ${json}\n\n`)
+      } catch (err) {
+        console.error(err)
+        res.status(500).json({ message: 'internal server error' })
+      }
     }
   })
 }

--- a/app/routes/sseRoutes.ts
+++ b/app/routes/sseRoutes.ts
@@ -3,6 +3,6 @@ import { sseHandler } from '../controllers/sseController'
 
 const router = Router()
 
-router.get('/sse', sseHandler)
+router.get('/users_updated_event', sseHandler)
 
 export default router

--- a/app/routes/sseRoutes.ts
+++ b/app/routes/sseRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express'
+import { sseHandler } from '../controllers/sseController'
+
+const router = Router()
+
+router.get('/sse', sseHandler)
+
+export default router


### PR DESCRIPTION
Server-Sent eventsで入室および退室イベントが発生した時にフロントエンドに在室者の配列を投げます。

```json5
// 例
[
  {
    "user_id": 1234,
    "user_name": "辻野あかり"
    "entered_at": "2021-03-10T14:54:59.000Z"
  },
  // 以下同...
]
```

クライアントサイドではこんな感じでデータが取得できます．JavaScriptの例です．

```javascript
const evtSource = new EventSource('http://localhost:3000/v1/sse')

evtSource.addEventListener('error', err => {
  console.error(err)
  // 再読み込みした時にも出るかも
  alert('サーバーとの通信が切断されました(再読み込みした時にも表示されます)')
})

// event名が指定されていないイベントが来たらこれが呼ばれる
evtSource.addEventListener('message', msgEvent => {
  console.log(msgEvent.data)
})

// イベント名は任意
evtSource.addEventListener('usersUpdated', msgEvent => {
  try {
    // dataプロパティが万一なかったらとりあえずからの配列を出す
    console.log(JSON.parse(msgEvent?.data ?? []))
  } catch (err) {
    console.error(err)
  }
})

// コネクションを確立したら呼ばれる
evtSource.addEventListener('open', event => {
  console.log('conneection established! (Event Source Interface)')
})
```

まだ実現できていないのは
- `user_name`プロパティ(メンバーを登録する・読み出すAPIが生えてないのでまだ無理．作るまで全員りんごアイドルになってもらう)
- 在室人数を示すプロパティが無い(付けろと言われればすぐ付けられる)
です．他にも思い出したら付け足します．レビューお願いします．
---
close #17 