### PR TITLE
ci.yml: aptをsudo下で動かすようにした

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
           persist-credentials: false
       - name: aptを最新化
         run: |
-          apt update
-          apt upgrade -y
+          sudo apt update
+          sudo apt upgrade -y
       - name: Java、ダウンローダ、解答ソフトをインストール
-        run: apt install -y openjdk-11-jre wget tar
+        run: sudo apt install -y openjdk-11-jre wget tar
       - name: Redpenのインストール
         env:
           Redpen_ver: 1.10.4


### PR DESCRIPTION
CIのログを見た感じ、aptが権限不足で死んでるっぽいです