### PR TITLE
フロントエンドへの通知(再)細かい改良を加えた

### DIFF
--- a/app/controllers/readerInputController.ts
+++ b/app/controllers/readerInputController.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-unused-vars */
 import { spawnSync } from 'child_process'
-import { EventEmitter } from 'events'
 import { Request, Response } from 'express'
 import { join } from 'path'
+import { emitter } from './sseController'
 import * as roomTable from '../models/inRoomUsersModel'
 import * as logsTable from '../models/accessLogsModel'
 import mysql from '../database/db'
@@ -14,15 +14,6 @@ const Status = {
   ERROR: 'error',
   FATAL: 'fatal'
 } as const
-
-// フロントエンドに通知するためのイベントを定義。sseHandler関数にlistenさせる
-const emitter = new EventEmitter()
-
-// 検知してもどうしようも無いがもしエラーが出たら記録する
-emitter.on('error', () => {
-  console.error('[!] Some error related to "emitter(node:events.EventEmitter)" has occured')
-  // さいきょうのえらーはんどりんぐ
-})
 
 function playWav (fileName: string) {
   // stdio: 'inherit'だとnodeのstdioに流れてしまって後で使えないので'pipe'
@@ -139,4 +130,4 @@ async function handleReaderInput (req: Request, res: Response) {
   res.status(204).send()
 }
 
-export { emitter, handleReaderInput }
+export { handleReaderInput }

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -70,10 +70,10 @@ async function sendUsersUpdatedEvent () {
 }
 
 /**
- * @param {Express.Request} req - HTTPリクエスト
- * @param {Express.Response} res - HTTPレスポンス
  * `/{version}/users_updated_event`に来たリクエストについて対応するレスポンスに
  * 適切なレスポンスヘッダーを設定して、それを配列`clients`に格納する関数。
+ * @param {Express.Request} req - HTTPリクエスト
+ * @param {Express.Response} res - HTTPレスポンス
  */
 function sseHandler (req: Request, res: Response) {
   // 適切なレスポンスヘッダーを設定
@@ -107,6 +107,10 @@ function sseHandler (req: Request, res: Response) {
 // listenerの登録
 emitter.on('usersUpdated', sendUsersUpdatedEvent)
 
+/**
+ * デバッグ用の関数。現在の`clients`と`emitter`の状態を表示する。
+ * `emitter`の状態はずっと同じはず。むしろ変化したら異常。
+ */
 // eslint-disable-next-line no-unused-vars
 function printCurState () {
   console.log(new Date().toISOString(), 'Current State')

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -75,7 +75,7 @@ async function sendUsersUpdatedEvent () {
  * @param {Express.Request} req - HTTPリクエスト
  * @param {Express.Response} res - HTTPレスポンス
  */
-function sseHandler (req: Request, res: Response) {
+function addSubscriber (req: Request, res: Response) {
   // 適切なレスポンスヘッダーを設定
   res.set({
     'Content-Type': 'text/event-stream; charset=utf-8', // event-streamでクライアント-サーバー間を繋ぎっぱなしにする
@@ -120,4 +120,4 @@ function printCurState () {
   console.log(`Current clients has ${clients.length} connection(s).`)
 }
 
-export { sseHandler }
+export { addSubscriber }

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -13,7 +13,7 @@ import EventEmitter from 'events'
  * Server-Sent eventsについて
  * https://html.spec.whatwg.org/multipage/server-sent-events.html
  */
-export function sseHandler (_req: Request, res: Response) {
+function sseHandler (_req: Request, res: Response) {
   res.set({
     'Content-Type': 'text/event-stream', // event-streamでクライアント-サーバー間を繋ぎっぱなしにする
     'Cache-Control': 'no-store' // レスポンスがキャッシュに保存されないようにする(クライアント側でも同じことをしているが一応)
@@ -56,3 +56,5 @@ export function sseHandler (_req: Request, res: Response) {
     }
   })
 }
+
+export { sseHandler }

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -55,7 +55,9 @@ async function sendUsersUpdatedEvent () {
     }
 
     try {
-      const json = JSON.stringify(users)
+      const json = JSON.stringify({
+        data: users
+      })
       // イベント名は任意。全て小文字の方がいいのかな?
       for (const client of clients) {
         client.res.status(200).write(`event: usersUpdated\ndata: ${json}\n\n`, 'utf-8')

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -2,7 +2,6 @@
 import { Request, Response } from 'express'
 import { emitter } from './readerInputController'
 import * as roomTable from '../models/inRoomUsersModel'
-import EventEmitter from 'events'
 
 // TODO あとでmodelsかどこかのファイルに移動する
 /**
@@ -21,16 +20,54 @@ interface NamedInRoomUser extends InRoomUser {
   'user_name': string | null
 }
 
+const clients: Response[] = []
+
 /**
- * @param {Express.Request} _req - HTTPリクエスト
- * @param {Express.Response} res - HTTPレスポンス
- * `/{version}/sse`に来たリクエストにストリームを開いて繋ぎっぱなしにする。
- * 在室者のリストの変更を検知して更新されたリストをpush(≒プッシュ通知)する。
+ * `usersUpdated`という`event`フィールドを持つSSEを配列`clients`内の全ての
+ * クライアントに対して投げる関数。`emitter`(events.EventEmitter)の発火する
+ * `usersUpdated`イベントのコールバック関数として使用する。80行目あたりを参照。
  *
  * Server-Sent eventsについて
  * https://html.spec.whatwg.org/multipage/server-sent-events.html
  */
+async function sendUsersUpdatedEvent () {
+  const [users, err] = await roomTable.listUsers()
+  if (err) {
+    // listUsers()でエラーがあったら一旦全クライアントとのストリームを閉じる。
+    for (const res of clients) {
+      // status codeが4xxや5xxだった時点でクライアント側ではEventSourceのerrorイベントが
+      // 発火し、数秒後に再接続をトライしてくる。だからここは迷わずコネクションを切ってよし。
+      // ただし何度もリトライされても困るのでクライアントには3回トライしたら止めるなど配慮してほしい。
+      res.status(500).json({ message: err?.message || 'internal server error' })
+    }
+  } else {
+    for (const user of users as NamedInRoomUser[]) {
+      user.user_name = null
+    }
+
+    try {
+      const json = JSON.stringify(users)
+      // イベント名は任意。全て小文字の方がいいのかな?
+      for (const res of clients) {
+        res.status(200).write(`event: usersUpdated\ndata: ${json}\n\n`)
+      }
+    } catch (err) {
+      console.error(err)
+      for (const res of clients) {
+        res.status(500).json({ message: 'internal server error' })
+      }
+    }
+  }
+}
+
+/**
+ * @param {Express.Request} _req - HTTPリクエスト
+ * @param {Express.Response} res - HTTPレスポンス
+ * `/{version}/users_updated_event`に来たリクエストについて対応するレスポンスに
+ * 適切なレスポンスヘッダーを設定して、それを配列`clients`に格納する関数。
+ */
 function sseHandler (_req: Request, res: Response) {
+  // 適切なレスポンスヘッダーを設定
   res.set({
     'Content-Type': 'text/event-stream', // event-streamでクライアント-サーバー間を繋ぎっぱなしにする
     'Cache-Control': 'no-store' // レスポンスがキャッシュに保存されないようにする(クライアント側でも同じことをしているが一応)
@@ -39,39 +76,22 @@ function sseHandler (_req: Request, res: Response) {
   // hello world
   res.status(200).write('data: hello\n\n') // nnは必須 コネクションが切れてしまうのでsend()は使わない
 
-  // ブラウザーの再読み込みを繰り返すとその度にEventEmitterにlistenerが追加され、10を超えると
-  // 'MaxListenersExceededWarning: Possible EventEmitter memory leak detected.'
-  // のような警告が出る。とりあえずは警告が出そうになったらこのイベントに登録済みのlistenerたちを解除する
-  // TODO EventEmitterからlistenerが外れてもフロントエンド側とのコネクションが切れるわけではないのでそこを何とかする
-  if (emitter.listenerCount('usersUpdated') + 1 > EventEmitter.defaultMaxListeners) {
-    emitter.removeAllListeners('usersUpdated')
-  }
+  // リストに追加
+  clients.push(res)
+  // printCurState() // デバッグ用
+}
 
-  // readerInputControllerで処理が走るとuserUpdatedイベントが発火するので、
-  // そのタイミングでクライアントにpushするためにリスナーを登録する
-  emitter.on('usersUpdated', async function sendUsersUpdatedEvent () {
-    const [users, err] = await roomTable.listUsers()
-    if (err) {
-      // status codeが4xxや5xxだった時点でクライアント側ではEventSourceのerrorイベントが
-      // 発火する。たぶん数秒後に再接続をトライする
-      res.status(500).json({ message: err?.message || 'internal server error' })
-    } else {
-      // TODO
-      // とりあえずuser_nameは仮で割り当てる。user_nameはstringかnullにしてある(undefinedではない!)
-      // 最悪Array<any>でも可
-      (users as NamedInRoomUser[]).forEach(user => {
-        user.user_name = null
-      })
-      try {
-        const json = JSON.stringify(users)
-        // イベント名は任意。全て小文字の方がいいのかな?
-        res.status(200).write(`event: usersUpdated\ndata: ${json}\n\n`)
-      } catch (err) {
-        console.error(err)
-        res.status(500).json({ message: 'internal server error' })
-      }
-    }
-  })
+// ここが最初に実行される
+// listenerの登録
+emitter.on('usersUpdated', sendUsersUpdatedEvent)
+
+// eslint-disable-next-line no-unused-vars
+function printCurState () {
+  console.log(new Date().toISOString(), 'Current State')
+  for (const evtName of emitter.eventNames()) {
+    console.log(`${emitter.listenerCount(evtName)} listener(s) is listening to ${String(evtName)} event.`)
+  }
+  console.log(`Current clients has ${clients.length} connection(s).`)
 }
 
 export { sseHandler }

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
+import { EventEmitter } from 'events'
 import { Request, Response } from 'express'
-import { emitter } from './readerInputController'
 import * as roomTable from '../models/inRoomUsersModel'
 
 // TODO あとでmodelsかどこかのファイルに移動する
@@ -31,7 +31,7 @@ let clients: {
 /**
  * `usersUpdated`という`event`フィールドを持つSSEを配列`clients`内の全ての
  * クライアントに対して投げる関数。`emitter`(events.EventEmitter)の発火する
- * `usersUpdated`イベントのコールバック関数として使用する。80行目あたりを参照。
+ * `usersUpdated`イベントのコールバック関数として使用する。111行目あたりを参照。
  *
  * Server-Sent eventsについて
  * https://html.spec.whatwg.org/multipage/server-sent-events.html
@@ -104,8 +104,17 @@ function addSubscriber (req: Request, res: Response) {
 }
 
 // ここが最初に実行される
+// フロントエンドに通知するためのイベントを定義する
+const emitter = new EventEmitter()
+
 // listenerの登録
 emitter.on('usersUpdated', sendUsersUpdatedEvent)
+
+// 検知してもどうしようも無いが、もしエラーが出たら記録する
+emitter.on('error', () => {
+  console.error('[!] Some error related to "emitter(node:events.EventEmitter)" has occured')
+  // さいきょうのえらーはんどりんぐ
+})
 
 /**
  * デバッグ用の関数。現在の`clients`と`emitter`の状態を表示する。
@@ -120,4 +129,4 @@ function printCurState () {
   console.log(`Current clients has ${clients.length} connection(s).`)
 }
 
-export { addSubscriber }
+export { emitter, addSubscriber }

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -5,12 +5,6 @@ import * as roomTable from '../models/inRoomUsersModel'
 import EventEmitter from 'events'
 
 /**
- * CORS用
- * // TODO corsブランチをマージしたら消す
- */
-const frontEndOrigin = 'http://localhost:8000'
-
-/**
  * @param {Express.Request} _req - HTTPリクエスト
  * @param {Express.Response} res - HTTPレスポンス
  * `/{version}/sse`に来たリクエストにストリームを開いて繋ぎっぱなしにする。
@@ -21,7 +15,6 @@ const frontEndOrigin = 'http://localhost:8000'
  */
 export function sseHandler (_req: Request, res: Response) {
   res.set({
-    'Access-Control-Allow-Origin': frontEndOrigin, // オリジン間リソース共有をこのオリジンとだけ許可
     'Content-Type': 'text/event-stream', // event-streamでクライアント-サーバー間を繋ぎっぱなしにする
     'Cache-Control': 'no-store' // レスポンスがキャッシュに保存されないようにする(クライアント側でも同じことをしているが一応)
   })

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -20,6 +20,9 @@ interface NamedInRoomUser extends InRoomUser {
   'user_name': string | null
 }
 
+/**
+ * SSEの送り先リスト
+ */
 const clients: Response[] = []
 
 /**
@@ -35,10 +38,10 @@ async function sendUsersUpdatedEvent () {
   if (err) {
     // listUsers()でエラーがあったら一旦全クライアントとのストリームを閉じる。
     for (const res of clients) {
-      // status codeが4xxや5xxだった時点でクライアント側ではEventSourceのerrorイベントが
+      // ストリームが(サーバー側から)閉じられた時にクライアント側ではEventSourceのerrorイベントが
       // 発火し、数秒後に再接続をトライしてくる。だからここは迷わずコネクションを切ってよし。
       // ただし何度もリトライされても困るのでクライアントには3回トライしたら止めるなど配慮してほしい。
-      res.status(500).json({ message: err?.message || 'internal server error' })
+      res.status(204).end()
     }
   } else {
     for (const user of users as NamedInRoomUser[]) {

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -4,6 +4,23 @@ import { emitter } from './readerInputController'
 import * as roomTable from '../models/inRoomUsersModel'
 import EventEmitter from 'events'
 
+// TODO あとでmodelsかどこかのファイルに移動する
+/**
+ * クライアントに返すデータの構造のもと
+ */
+interface InRoomUser {
+  'user_id': number,
+  'entered_at': Date
+}
+
+// TODO あとでmodelsかどこかのファイルに移動する
+/**
+ * クライアントに返すデータの構造
+ */
+interface NamedInRoomUser extends InRoomUser {
+  'user_name': string | null
+}
+
 /**
  * @param {Express.Request} _req - HTTPリクエスト
  * @param {Express.Response} res - HTTPレスポンス
@@ -42,7 +59,7 @@ function sseHandler (_req: Request, res: Response) {
       // TODO
       // とりあえずuser_nameは仮で割り当てる。user_nameはstringかnullにしてある(undefinedではない!)
       // 最悪Array<any>でも可
-      (users as Array<{ user_id: number, user_name: string | null, entered_at: Date }>).forEach(user => {
+      (users as NamedInRoomUser[]).forEach(user => {
         user.user_name = null
       })
       try {

--- a/app/controllers/sseController.ts
+++ b/app/controllers/sseController.ts
@@ -52,12 +52,12 @@ async function sendUsersUpdatedEvent () {
       const json = JSON.stringify(users)
       // イベント名は任意。全て小文字の方がいいのかな?
       for (const res of clients) {
-        res.status(200).write(`event: usersUpdated\ndata: ${json}\n\n`)
+        res.status(200).write(`event: usersUpdated\ndata: ${json}\n\n`, 'utf-8')
       }
     } catch (err) {
       console.error(err)
       for (const res of clients) {
-        res.status(500).json({ message: 'internal server error' })
+        res.status(204).end()
       }
     }
   }
@@ -72,12 +72,14 @@ async function sendUsersUpdatedEvent () {
 function sseHandler (_req: Request, res: Response) {
   // 適切なレスポンスヘッダーを設定
   res.set({
-    'Content-Type': 'text/event-stream', // event-streamでクライアント-サーバー間を繋ぎっぱなしにする
+    'Content-Type': 'text/event-stream; charset=utf-8', // event-streamでクライアント-サーバー間を繋ぎっぱなしにする
     'Cache-Control': 'no-store' // レスポンスがキャッシュに保存されないようにする(クライアント側でも同じことをしているが一応)
   })
+  // https://stackoverflow.com/questions/7636165/how-do-server-sent-events-actually-work/11998868
+  res.flushHeaders()
 
   // hello world
-  res.status(200).write('data: hello\n\n') // nnは必須 コネクションが切れてしまうのでsend()は使わない
+  res.status(200).write('data: hello\n\n', 'utf-8') // nnは必須 コネクションが切れてしまうのでsend()は使わない
 
   // リストに追加
   clients.push(res)

--- a/app/routes/inRoomUsersRoutes.ts
+++ b/app/routes/inRoomUsersRoutes.ts
@@ -6,7 +6,7 @@ const router = Router()
 // Retrieve all users in the room
 router.get('/users_in_room', listUsers)
 
-// Find a user in the room by user_id
-router.get('/users_in_room/:user_id', getUser)
+// Find a user in the room by user_id (user_idが数字のときここにマッチ)
+router.get('/users_in_room/:user_id(\\d+)', getUser)
 
 export default router

--- a/app/routes/sseRoutes.ts
+++ b/app/routes/sseRoutes.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express'
-import { sseHandler } from '../controllers/sseController'
+import { addSubscriber } from '../controllers/sseController'
 
 const router = Router()
 
-router.get('/users_updated_event', sseHandler)
+// router.get('/subscribe', addSubscriber) // こっちでもいいかも
+router.get('/users_updated_event', addSubscriber)
 
 export default router


### PR DESCRIPTION
- 他のエンドポイントにならって返すJSONにdataプロパティを作り，そこに配列データを引っつけるように変更した．(実際返すときは文字列になってる)
- 接続が切れたときの対策を見直した
- SSEに関係はないが，ルーターにバリデーションを追加した．
- その他，誤字脱字の修正などを行った．