### PR TITLE
npmスクリプトのタイポ修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "build": "tsc -p .",
-    "dev": "ts-node-dev --respawn --kill-child ams-backend-server.ts",
+    "dev": "ts-node-dev --respawn --exit-child ams-backend-server.ts",
     "lint": "eslint . --ext .js,.ts",
     "start": "npm run build && node dist/ams-backend-server.js",
     "test": "jest"


### PR DESCRIPTION
タイポがあったので修正しました．本当は前回のPR時に手元で動作チェックした時にも
```plain
error command sh -c ts-node-dev --respawn --kill-child ams-backend-server.ts
```
というエラーが出ていたのですが，自分の環境のせいだと思いこんでいて承認してしまっていました．普通にタイポだと気づけたはずでした．すいません．