### PR TITLE
reviewdog.yml: 報告するレベルをinfoに変更

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -14,4 +14,5 @@ jobs:
         with:
           eslint_flags: '. --ext .js,.ts'
           fail_on_error: true
+          level: info
           reporter: github-pr-review


### PR DESCRIPTION
以前の設定だと`warning`レベルが報告されなかった